### PR TITLE
fix for emscripten 2.0.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vst: vst/vst-native-orb@4.0.3
+  vst: vst/vst-native-orb@5.0.3
 
 .current_filters: &current_filters
   branches:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     --post-js ${POST_JS}
     --bind
     -s ASSERTIONS=1
-    -s EXTRA_EXPORTED_RUNTIME_METHODS=['ccall,cwrap']
+    -s EXPORTED_RUNTIME_METHODS=['ccall,cwrap']
     -s WASM=1
     -s NO_EXIT_RUNTIME=1
     -s ALLOW_MEMORY_GROWTH=1

--- a/src/messaging.js
+++ b/src/messaging.js
@@ -21,7 +21,7 @@ self.onmessage = (e) => {
   }
 
   if (!valid) {
-    sendError(msg.id, `Method doesn't exist: ${msg.method}`);
+    self.sendError(msg.id, `Method doesn't exist: ${msg.method}`);
   }
 };
 

--- a/src/objtracking.cpp
+++ b/src/objtracking.cpp
@@ -11,7 +11,7 @@ using OpStatus = vst::TrackerResult::OpStatus;
 #ifdef __EMSCRIPTEN__
 #define sendError(reqId,errmsg) do { \
     EM_ASM({ \
-      sendError($0,{ \
+      self.sendError($0,{ \
         error: errmsg \
       }); \
     }, reqId); \
@@ -29,7 +29,7 @@ namespace
   void sendResponse(int id)
   {
 #ifdef __EMSCRIPTEN__
-    EM_ASM({ sendResult($0) }, id);
+    EM_ASM({ self.sendResult($0) }, id);
 #else
     printf("[***] Success (id=%d)\n", id);
 #endif
@@ -38,7 +38,7 @@ namespace
   {
 #ifdef __EMSCRIPTEN__
       EM_ASM({
-        sendResult($0, $1);
+        self.sendResult($0, $1);
       },
         id, trackingCtxId
       );
@@ -51,7 +51,7 @@ namespace
   {
 #ifdef __EMSCRIPTEN__
       EM_ASM({
-        sendResult($0, {
+        self.sendResult($0, {
           x: $1,
           y: $2,
           timeStamp: $3

--- a/src/videoutils.cpp
+++ b/src/videoutils.cpp
@@ -25,7 +25,7 @@ extern "C"
 #ifdef __EMSCRIPTEN__
 #define sendError(reqId,errmsg) do { \
     EM_ASM({ \
-      sendError($0,{ \
+      self.sendError($0,{ \
         error: errmsg \
       }); \
     }, reqId); \
@@ -64,7 +64,7 @@ namespace
   void sendResponse(int id)
   {
 #ifdef __EMSCRIPTEN__
-    EM_ASM({ sendResult($0) }, id);
+    EM_ASM({ self.sendResult($0) }, id);
 #else
     printf("[***] Success (id=%d)\n", id);
 #endif
@@ -77,7 +77,7 @@ namespace
       EM_ASM({
         const codecStr = UTF8ToString($8);
 
-        sendResult($0, {
+        self.sendResult($0, {
           avgFrameRate: $1,
           realFrameRate: $2,
           numFrames: $3,


### PR DESCRIPTION
* The 2.0.30 toolchain was failing to resolve the sendError() and sendResult() JS script functions; making the self explicit seems to fix that.
* Address the EXTRA_EXPORTED_RUNTIME_METHODS deprecation. 