### PR TITLE
MEG-1474 Secrets cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,5 +130,6 @@ workflows:
     jobs:
       - build:
           <<: *params
+          context: orb-publishing
           filters:
             <<: *current_filters


### PR DESCRIPTION
CircleCI secret cleanup. use contexts for env vars, rather than project-specifc env vars. Once this is merged, I will delete all of the project-specific env vars